### PR TITLE
✨feat: 회원탈퇴 및 스케줄링 구현

### DIFF
--- a/src/main/java/refresh/acci/domain/analysis/model/Analysis.java
+++ b/src/main/java/refresh/acci/domain/analysis/model/Analysis.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 import refresh.acci.domain.analysis.model.enums.AnalysisStatus;
 import refresh.acci.domain.analysis.model.enums.AccidentType;
+import refresh.acci.global.common.BaseTime;
 
 import java.util.UUID;
 
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "analysis")
-public class Analysis {
+public class Analysis extends BaseTime {
 
     @Id
     @GeneratedValue

--- a/src/main/java/refresh/acci/domain/auth/application/AuthCodeCleanupScheduler.java
+++ b/src/main/java/refresh/acci/domain/auth/application/AuthCodeCleanupScheduler.java
@@ -1,0 +1,31 @@
+package refresh.acci.domain.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import refresh.acci.domain.auth.infra.AuthCodeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthCodeCleanupScheduler {
+
+    private final AuthCodeRepository authCodeRepository;
+
+    /**
+     * 만료된 인증 코드 정리
+     * 매 1분마다 실행
+     */
+    @Scheduled(fixedRate = 60000)
+    public void cleanupExpiredCodes() {
+        int beforeSize = authCodeRepository.size();
+        authCodeRepository.removeExpiredCodes();
+        int afterSize = authCodeRepository.size();
+
+        int removedCount = beforeSize - afterSize;
+        if (removedCount > 0) {
+            log.info("만료된 인증 코드 {}개 정리 완료", removedCount);
+        }
+    }
+}

--- a/src/main/java/refresh/acci/domain/auth/infra/AuthCodeRepository.java
+++ b/src/main/java/refresh/acci/domain/auth/infra/AuthCodeRepository.java
@@ -11,4 +11,8 @@ public interface AuthCodeRepository {
     Optional<AuthCode> findByCode(String code);
 
     void deleteByCode(String code);
+
+    void removeExpiredCodes();
+
+    int size();
 }

--- a/src/main/java/refresh/acci/domain/auth/infra/InMemoryAuthCodeRepository.java
+++ b/src/main/java/refresh/acci/domain/auth/infra/InMemoryAuthCodeRepository.java
@@ -41,14 +41,15 @@ public class InMemoryAuthCodeRepository implements AuthCodeRepository {
         storage.remove(code);
     }
 
-    @Scheduled(fixedRate = 60000)
-    public void cleanupExpiredCodes() {
-        int beforeSize = storage.size();
+    @Override
+    public void removeExpiredCodes() {
         storage.entrySet().removeIf(entry -> entry.getValue().isExpired());
-        int afterSize = storage.size();
-
-        if (beforeSize != afterSize) {
-            log.info("만료된 인증 코드 {}개 정리 완료", beforeSize - afterSize);
-        }
     }
+
+    @Override
+    public int size() {
+        return storage.size();
+    }
+
+
 }

--- a/src/main/java/refresh/acci/domain/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/refresh/acci/domain/auth/oauth/CustomOAuth2UserService.java
@@ -45,7 +45,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private User saveOrUpdate(OAuthAttributes attributes) {
         Provider provider = Provider.from(attributes.getProvider());
 
-        User user = userRepository.findByProviderAndProviderId(provider, attributes.getProviderId())
+        User user = userRepository.findByProviderAndProviderIdAndDeletedFalse(provider, attributes.getProviderId())
                 .map(existingUser -> updateUser(existingUser, attributes))
                 .orElseGet(() -> createUser(attributes));
 

--- a/src/main/java/refresh/acci/domain/law/model/Law.java
+++ b/src/main/java/refresh/acci/domain/law/model/Law.java
@@ -4,12 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import refresh.acci.global.common.BaseTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "law")
-public class Law {
+public class Law extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/refresh/acci/domain/precedent/model/Precedent.java
+++ b/src/main/java/refresh/acci/domain/precedent/model/Precedent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import refresh.acci.global.common.BaseTime;
 
 import java.time.LocalDate;
 
@@ -11,7 +12,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "precedent")
-public class Precedent {
+public class Precedent extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/refresh/acci/domain/term/model/Term.java
+++ b/src/main/java/refresh/acci/domain/term/model/Term.java
@@ -4,12 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import refresh.acci.global.common.SoftDelete;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "term")
-public class Term {
+public class Term extends SoftDelete {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/refresh/acci/domain/user/application/CustomUserDetailsService.java
+++ b/src/main/java/refresh/acci/domain/user/application/CustomUserDetailsService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String providerId) throws UsernameNotFoundException {
-        User user = userRepository.findByProviderId(providerId)
+        User user = userRepository.findByProviderIdAndDeletedFalse(providerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return new CustomUserDetails(user);
     }

--- a/src/main/java/refresh/acci/domain/user/application/MyPageService.java
+++ b/src/main/java/refresh/acci/domain/user/application/MyPageService.java
@@ -1,5 +1,6 @@
 package refresh.acci.domain.user.application;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import refresh.acci.domain.user.model.User;
 import refresh.acci.domain.user.presentation.dto.MyPageResponse;
 import refresh.acci.global.exception.CustomException;
 import refresh.acci.global.exception.ErrorCode;
+import refresh.acci.global.util.CookieUtil;
 
 @Slf4j
 @Service
@@ -23,20 +25,20 @@ public class MyPageService {
         return MyPageResponse.of(user);
     }
 
-    /*
-    회의 후 softDelete 및 정보 보관 기간 설정
+
     @Transactional
     public void deleteAccount(Long userId, HttpServletResponse response) {
         User user = findUserById(userId);
         String providerId = user.getProviderId();
-        userRepository.deleteById(userId);
+
+        user.softDelete();
+
         CookieUtil.deleteRefreshTokenCookie(response);
         log.info("회원 탈퇴 완료 - userId: {}, providerId: {}", userId, providerId);
     }
-     */
 
     private User findUserById(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndDeletedFalse(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/refresh/acci/domain/user/application/UserDeletionScheduler.java
+++ b/src/main/java/refresh/acci/domain/user/application/UserDeletionScheduler.java
@@ -1,0 +1,47 @@
+package refresh.acci.domain.user.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import refresh.acci.domain.user.infra.UserRepository;
+import refresh.acci.domain.user.model.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDeletionScheduler {
+
+    private final UserRepository userRepository;
+
+    //보관 기간: 6개월(180일)
+    private static final int RETENTION_DAYS = 180;
+
+    /**
+     * 6개월 이상 지난 탈퇴 사용자 물리 삭제
+     * 매일 새벽 03:00 시행 (Asia/Seoul 시간대)
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void deleteExpiredUsers() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(RETENTION_DAYS);
+
+        log.info("탈퇴 사용자 삭제 스케줄 시작 - 기준일: {}", cutoffDate);
+
+        List<User> usersToDelete = userRepository.findByDeletedTrueAndDeletedAtBefore(cutoffDate);
+
+        if (usersToDelete.isEmpty()) {
+            log.info("삭제할 탈퇴 사용자 없음");
+            return;
+        }
+
+        int deletedCount = usersToDelete.size();
+        userRepository.deleteAll(usersToDelete);
+
+        log.info("탈퇴 사용자 {}명 물리 삭제 완료", deletedCount);
+    }
+}

--- a/src/main/java/refresh/acci/domain/user/infra/UserRepository.java
+++ b/src/main/java/refresh/acci/domain/user/infra/UserRepository.java
@@ -4,9 +4,22 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import refresh.acci.domain.user.model.Provider;
 import refresh.acci.domain.user.model.User;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    // === 활성 사용자 조회 (deleted = false) ===
+    Optional<User> findByIdAndDeletedFalse(Long id);
+    Optional<User> findByProviderIdAndDeletedFalse(String providerId);
+    Optional<User> findByProviderAndProviderIdAndDeletedFalse(Provider provider, String providerId);
+
+    // === 전체 사용자 조회 (탈퇴 포함) ===
     Optional<User> findByProviderId(String providerId);
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
+
+    // === 물리 삭제용 ===
+    List<User> findByDeletedTrueAndDeletedAtBefore(LocalDateTime cutoffDate);
+
 }

--- a/src/main/java/refresh/acci/domain/user/model/User.java
+++ b/src/main/java/refresh/acci/domain/user/model/User.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import refresh.acci.global.common.SoftDelete;
 
 @Entity
 @Getter
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
                 @UniqueConstraint(columnNames = {"provider", "provider_id"})
         }
 )
-public class User {
+public class User extends SoftDelete {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/refresh/acci/domain/user/presentation/MyPageController.java
+++ b/src/main/java/refresh/acci/domain/user/presentation/MyPageController.java
@@ -26,11 +26,11 @@ public class MyPageController implements MyPageApiSpecification{
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    /*
+
     @DeleteMapping
     public ResponseEntity<Void> deleteAccount(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletResponse response) {
         myPageService.deleteAccount(userDetails.getId(), response);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
-     */
+
 }

--- a/src/main/java/refresh/acci/global/common/BaseTime.java
+++ b/src/main/java/refresh/acci/global/common/BaseTime.java
@@ -1,0 +1,24 @@
+package refresh.acci.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/refresh/acci/global/common/SoftDelete.java
+++ b/src/main/java/refresh/acci/global/common/SoftDelete.java
@@ -1,0 +1,27 @@
+package refresh.acci.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class SoftDelete extends BaseTime {
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.deleted = false;
+        this.deletedAt = null;
+    }
+}

--- a/src/main/java/refresh/acci/global/config/JpaConfig.java
+++ b/src/main/java/refresh/acci/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package refresh.acci.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
## 📎 관련 이슈

- #2 

## 📄 설명

- 회원탈퇴 API 활성화 및 soft delete 구현
- 스케줄러를 통해 매일 03:00 삭제된지 6개월이 지난 유저정보 삭제
- 각 repository에 softdelete 검증 쿼리 추가

## 🤔 추후 작업 사항

- 마이페이지 조회시 최근 분석, 최근 수리비 견적 필드 추가
- 유저정보 삭제시 고아객체 방지를 위한 삭제 범위 지정 및 코드 수정 필요
