### PR TITLE
✨feat: 수리비 견적 금액을 단일값에서 범위로 전환

### DIFF
--- a/src/main/java/refresh/acci/domain/repair/application/service/RepairEstimateWorkerService.java
+++ b/src/main/java/refresh/acci/domain/repair/application/service/RepairEstimateWorkerService.java
@@ -67,17 +67,23 @@ public class RepairEstimateWorkerService {
         RepairEstimateLlmResponse llmResponse = callLlm(estimate.getVehicleInfo(), damageDetails, imagesData);
         log.info("LLM response repairItems: {}", llmResponse.getRepairItems());
 
+        //LLM 응답 검증
+        validateLlmResponse(llmResponse);
+
         //RepairItem 저장
         saveRepairItems(estimateId, llmResponse.getRepairItems());
 
         //총 금액 계산
-        long totalCost = llmResponse.getRepairItems().stream()
-                .mapToLong(RepairEstimateLlmResponse.RepairItem::getCost)
+        long totalCostMin = llmResponse.getRepairItems().stream()
+                .mapToLong(RepairEstimateLlmResponse.RepairItem::getCostMin)
+                .sum();
+        long totalCostMax = llmResponse.getRepairItems().stream()
+                .mapToLong(RepairEstimateLlmResponse.RepairItem::getCostMax)
                 .sum();
 
         //COMPLETED 상태로 변경
-        estimate.completeEstimate(totalCost);
-        log.info("수리비 견적 처리 완료 - estimateId: {}, totalEstimate: {}", estimateId, totalCost);
+        estimate.completeEstimate(totalCostMin, totalCostMax);
+        log.info("수리비 견적 처리 완료 - estimateId: {}, totalEstimate: {} ~ {}", estimateId, totalCostMin, totalCostMax);
     }
 
     //S3 키 리스트로 이미지 리스트 변환
@@ -140,11 +146,30 @@ public class RepairEstimateWorkerService {
                         estimateId,
                         dto.getPartName(),
                         RepairMethod.from(dto.getRepairMethod()),
-                        dto.getCost()
+                        dto.getCostMin(),
+                        dto.getCostMax()
                 ))
                 .toList();
 
         repairItemRepository.saveAll(repairItems);
+    }
+
+    //LLM 응답 형식 검증 (null / 음수 / cost_min > cost_max)
+    private void validateLlmResponse(RepairEstimateLlmResponse response) {
+        List<RepairEstimateLlmResponse.RepairItem> items = response.getRepairItems();
+        if (items == null || items.isEmpty()) {
+            log.warn("LLM 응답에 repair_items가 비어 있습니다.");
+            throw new CustomException(ErrorCode.LLM_RESPONSE_PARSE_FAILED);
+        }
+
+        for (RepairEstimateLlmResponse.RepairItem item : items) {
+            Long costMin = item.getCostMin();
+            Long costMax = item.getCostMax();
+            if (costMin == null || costMax == null || costMin < 0 || costMax < 0 || costMin > costMax) {
+                log.warn("LLM 응답 금액 검증 실패 - partName: {}, costMin: {}, costMax: {}", item.getPartName(), costMin, costMax);
+                throw new CustomException(ErrorCode.LLM_RESPONSE_PARSE_FAILED);
+            }
+        }
     }
 
     //실패 처리

--- a/src/main/java/refresh/acci/domain/repair/infra/llm/RepairPromptBuilder.java
+++ b/src/main/java/refresh/acci/domain/repair/infra/llm/RepairPromptBuilder.java
@@ -51,8 +51,11 @@ public class RepairPromptBuilder {
                 2. 입력된 각 damage_detail에 대해 정확히 1개의 repair_item을 생성하세요.
                 3. part_name은 입력된 한국어 부위명(part_name_kr)을 그대로 사용하세요.
                 4. repair_method는 반드시 다음 중 하나: "replace", "repair", "paint", "repair_and_paint"
-                5. cost는 만원 단위가 아닌 원(₩) 단위 정수로 작성하세요. (예: 45만원 → 450000)
-                6. 차량의 segment(차급)에 해당하는 배율을 적용한 금액을 산출하세요.
+                5. 수리비는 단일 금액이 아닌 최소~최대 범위로 산출하세요.
+                   - 위 가격 가이드라인의 범위를 기준으로 삼되, 손상 상태·연식·이미지를 고려하여 가이드라인 범위 안에서 더 좁은 범위로 산출하세요.
+                   - cost_min, cost_max는 만원 단위가 아닌 원(₩) 단위 정수로 작성하세요. (예: 45만원 → 450000)
+                   - 반드시 cost_min <= cost_max 를 지키세요.
+                6. 차량의 segment(차급)에 해당하는 배율을 cost_min, cost_max 양쪽에 동일하게 적용하세요.
                 
                 응답 JSON 형식:
                 {
@@ -60,7 +63,8 @@ public class RepairPromptBuilder {
                     {
                       "part_name": "부위명 (한국어)",
                       "repair_method": "replace|repair|paint|repair_and_paint",
-                      "cost": 수리비(원 단위 정수)
+                      "cost_min": 최소 수리비(원 단위 정수),
+                      "cost_max": 최대 수리비(원 단위 정수)
                     }
                   ]
                 }

--- a/src/main/java/refresh/acci/domain/repair/infra/llm/dto/RepairEstimateLlmResponse.java
+++ b/src/main/java/refresh/acci/domain/repair/infra/llm/dto/RepairEstimateLlmResponse.java
@@ -23,6 +23,10 @@ public class RepairEstimateLlmResponse {
         @JsonProperty("repair_method")
         private String repairMethod;
 
-        private Long cost;
+        @JsonProperty("cost_min")
+        private Long costMin;
+
+        @JsonProperty("cost_max")
+        private Long costMax;
     }
 }

--- a/src/main/java/refresh/acci/domain/repair/model/RepairEstimate.java
+++ b/src/main/java/refresh/acci/domain/repair/model/RepairEstimate.java
@@ -42,8 +42,11 @@ public class RepairEstimate extends BaseTime {
     @Column(name = "estimate_status", nullable = false)
     private EstimateStatus estimateStatus;
 
-    @Column(name = "total_estimated_cost")
-    private Long totalEstimatedCost;
+    @Column(name = "total_estimated_cost_min")
+    private Long totalEstimatedCostMin;
+
+    @Column(name = "total_estimated_cost_max")
+    private Long totalEstimatedCostMax;
 
     @Builder
     public RepairEstimate(Long userId, VehicleInfo vehicleInfo) {
@@ -71,8 +74,9 @@ public class RepairEstimate extends BaseTime {
         this.estimateStatus = EstimateStatus.PROCESSING;
     }
 
-    public void completeEstimate(Long totalCost) {
-        this.totalEstimatedCost = totalCost;
+    public void completeEstimate(Long totalCostMin, Long totalCostMax) {
+        this.totalEstimatedCostMin = totalCostMin;
+        this.totalEstimatedCostMax = totalCostMax;
         this.estimateStatus = EstimateStatus.COMPLETED;
     }
 

--- a/src/main/java/refresh/acci/domain/repair/model/RepairItem.java
+++ b/src/main/java/refresh/acci/domain/repair/model/RepairItem.java
@@ -32,23 +32,28 @@ public class RepairItem {
     @Column(name = "repair_method", nullable = false)
     private RepairMethod repairMethod;
 
-    @Column(name = "cost", nullable = false)
-    private Long cost;
+    @Column(name = "cost_min", nullable = false)
+    private Long costMin;
+
+    @Column(name = "cost_max", nullable = false)
+    private Long costMax;
 
     @Builder
-    public RepairItem(UUID repairEstimateId, String partName, RepairMethod repairMethod, Long cost) {
+    public RepairItem(UUID repairEstimateId, String partName, RepairMethod repairMethod, Long costMin, Long costMax) {
         this.repairEstimateId = repairEstimateId;
         this.partName = partName;
         this.repairMethod = repairMethod;
-        this.cost = cost;
+        this.costMin = costMin;
+        this.costMax = costMax;
     }
 
-    public static RepairItem of(UUID repairEstimateId, String partName, RepairMethod repairMethod, Long cost) {
+    public static RepairItem of(UUID repairEstimateId, String partName, RepairMethod repairMethod, Long costMin, Long costMax) {
         return RepairItem.builder()
                 .repairEstimateId(repairEstimateId)
                 .partName(partName)
                 .repairMethod(repairMethod)
-                .cost(cost)
+                .costMin(costMin)
+                .costMax(costMax)
                 .build();
     }
 }

--- a/src/main/java/refresh/acci/domain/repair/presentation/RepairEstimateApiSpecification.java
+++ b/src/main/java/refresh/acci/domain/repair/presentation/RepairEstimateApiSpecification.java
@@ -33,7 +33,7 @@ public interface RepairEstimateApiSpecification {
     @Operation(
             summary = "수리비 견적 요청",
             description = "차량 정보와 손상 내역을 바탕으로 AI가 수리비 견적을 산출합니다. <br><br>" +
-                    "LLM이 각 부위별 수리 방법과 비용을 분석하여 총 견적을 제공합니다. <br><br>" +
+                    "LLM이 각 부위별 수리 방법과 비용을 분석하여 최소~최대 범위의 견적을 제공합니다. <br><br>" +
                     "이미지는 선택 사항이며, 최대 5장까지 첨부 가능하고 첨부 시 LLM이 이미지를 추가 참고자료로 활용합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     content = @Content(
@@ -114,7 +114,7 @@ public interface RepairEstimateApiSpecification {
     @Operation(
             summary = "수리비 견적 조회",
             description = "생성된 수리비 견적의 상세 정보를 조회합니다. <br><br>" +
-                    "차량 정보, 손상 내역, 부위별 수리 항목, 총 견적 금액을 제공합니다.",
+                    "차량 정보, 손상 내역, 부위별 수리 항목, 총 견적 금액 범위(최소~최대)를 제공합니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -142,7 +142,7 @@ public interface RepairEstimateApiSpecification {
             summary = "수리비 견적 페이징 조회",
             description = "인증된 사용자의 수리비 견적 기록을 페이징하여 조회합니다. <br><br>" +
                     "최신순으로 정렬되며, 기본 페이지 크기는 5개입니다. <br><br>" +
-                    "요약 정보(견적 ID, 상태, 총 견적 금액, 차량 모델, 손상 요약, 생성일)만 포함되며, " +
+                    "요약 정보(견적 ID, 상태, 총 견적 금액 범위, 차량 모델, 손상 요약, 생성일)만 포함되며, " +
                     "상세 정보는 단건 조회 API를 사용하세요. <br><br>" +
                     "이 API는 인증이 필요하며, HttpOnly 쿠키에 저장된 Access Token이 자동으로 전송됩니다.",
             responses = {

--- a/src/main/java/refresh/acci/domain/repair/presentation/dto/RepairEstimateResponse.java
+++ b/src/main/java/refresh/acci/domain/repair/presentation/dto/RepairEstimateResponse.java
@@ -20,7 +20,8 @@ public class RepairEstimateResponse {
     private final List<String> images;
     private final List<DamageDetailDto> damageDetails;
     private final List<RepairItemDto> repairItems;
-    private final Long totalEstimate;
+    private final Long totalEstimateMin;
+    private final Long totalEstimateMax;
     private final String status;
     private final LocalDateTime createdAt;
 
@@ -36,7 +37,8 @@ public class RepairEstimateResponse {
                 .repairItems(repairItems.stream()
                         .map(RepairItemDto::from)
                         .toList())
-                .totalEstimate(estimate.getTotalEstimatedCost())
+                .totalEstimateMin(estimate.getTotalEstimatedCostMin())
+                .totalEstimateMax(estimate.getTotalEstimatedCostMax())
                 .status(estimate.getEstimateStatus().name())
                 .createdAt(estimate.getCreatedAt())
                 .build();
@@ -85,13 +87,15 @@ public class RepairEstimateResponse {
     public static class RepairItemDto {
         private final String partName;
         private final String repairMethod;
-        private final Long cost;
+        private final Long costMin;
+        private final Long costMax;
 
         public static RepairItemDto from(RepairItem item) {
             return RepairItemDto.builder()
                     .partName(item.getPartName())
                     .repairMethod(item.getRepairMethod().getDisplayName())
-                    .cost(item.getCost())
+                    .costMin(item.getCostMin())
+                    .costMax(item.getCostMax())
                     .build();
         }
     }

--- a/src/main/java/refresh/acci/domain/repair/presentation/dto/RepairEstimateSummaryResponse.java
+++ b/src/main/java/refresh/acci/domain/repair/presentation/dto/RepairEstimateSummaryResponse.java
@@ -15,7 +15,8 @@ import java.util.UUID;
 public class RepairEstimateSummaryResponse {
     private final UUID estimateId;
     private final EstimateStatus estimateStatus;
-    private final Long totalEstimate;
+    private final Long totalEstimateMin;
+    private final Long totalEstimateMax;
     private final String vehicleModel;
     private final String damageSummary;
     private final LocalDateTime createdAt;
@@ -24,7 +25,8 @@ public class RepairEstimateSummaryResponse {
         return RepairEstimateSummaryResponse.builder()
                 .estimateId(estimate.getId())
                 .estimateStatus(estimate.getEstimateStatus())
-                .totalEstimate(estimate.getTotalEstimatedCost())
+                .totalEstimateMin(estimate.getTotalEstimatedCostMin())
+                .totalEstimateMax(estimate.getTotalEstimatedCostMax())
                 .vehicleModel(estimate.getVehicleInfo().getModel())
                 .damageSummary(buildDamageSummary(damageDetails))
                 .createdAt(estimate.getCreatedAt())


### PR DESCRIPTION
## 📎 관련 이슈

- #88 

## 📄 설명

## 개요
수리비 견적의 금액을 단일값에서 **범위(최소~최대)** 형식으로 전환합니다.
"단일 금액보다 범위로 보여주는 것이 적절하다"는 의견을 반영했습니다.

## 배경
- 기존에는 부위별/총 견적 금액이 단일 `Long` 값이었음
- 가격 가이드라인(`RepairCostReference`)은 원래 범위 형태인데, LLM에게 단일값을
  산출하도록 지시해 범위 정보가 단일값으로 붕괴되고 있었음

## 산출 방식
- **하이브리드(가이드라인 기반 LLM 범위 산출)** 채택
- 출처가 있는 가격 가이드라인 범위를 기준으로, LLM이 손상 상태·연식·이미지를
  고려해 그 범위 안에서 더 좁은 min~max를 산출
- 서버는 LLM 결과를 신뢰하되, 형식 검증(null/음수/min>max)만 수행
  → 가이드라인 = 타당성 근거, LLM = 사진 기반 정밀화

## 주요 변경
| 구분 | 변경 내용 |
|------|-----------|
| Entity | `RepairItem.cost` → `costMin`/`costMax`, `RepairEstimate.totalEstimatedCost` → min/max |
| LLM | 응답 DTO·프롬프트를 범위 산출 방식으로 변경 |
| 검증 | LLM 응답 형식 검증 추가 (실패 시 견적 FAILED) |
| Response | 단건·페이징 응답 DTO를 범위 필드로 교체 |
| Docs | Swagger 명세 문구 정리 |

## 변경 파일
- `RepairItem`, `RepairEstimate`
- `RepairEstimateLlmResponse`, `RepairPromptBuilder`
- `RepairEstimateWorkerService`
- `RepairEstimateResponse`, `RepairEstimateSummaryResponse`
- `RepairEstimateApiSpecification`

## 리뷰 포인트
- 하이브리드 산출 방식(LLM 범위 신뢰 + 서버 형식 검증)의 적절성
- LLM 응답 검증 실패 시 견적 전체를 FAILED로 처리하는 정책
- 페이징 응답에 대표 단일값 없이 범위만 노출하는 것에 대한 프론트 합의 여부

## 후속 과제 (이번 PR 범위 밖)
- 가이드라인 범위를 벗어난 LLM 출력에 대한 클램핑 가드레일
- `ddl-auto: validate` 전환 + Flyway 도입 검토

## 🤔 추후 작업 사항

- ex) 성능 개선 필요